### PR TITLE
RAND: add shift reg

### DIFF
--- a/verilog/RAND.v
+++ b/verilog/RAND.v
@@ -12,19 +12,19 @@
 
 
 module RAND (
-        input wire clk,
-        input wire [7:0] addr,
-        input wire write_en,
-        input wire rst,
-        input wire [7:0] din,
+        input  wire       clk,
+        input  wire [7:0] addr,
+        input  wire       write_en,
+        input  wire       rst,
+        input  wire [7:0] din,
         output wire [7:0] dout
     );
 
     localparam
         //SEED = 16'b 100_0010_1001,
-        SEED = {8'h01, 8'h77},
-        RULE = 8'd 30,
-        WIDTH = 16;
+        SEED  = {7'h01, 8'h77},
+        RULE  = 8'd 30,
+        WIDTH = 15;
 
     reg ini = 0;
     always @(posedge(clk))
@@ -45,19 +45,27 @@ module RAND (
 
     always @(posedge(clk))
         if( ini == 0 ) q <= SEED;
-        else if( write_en ) q <= {8'h01,din};
+        else if( write_en ) q <= {7'h01,din};
         else q <= out;
 
     assign in = q;
-    assign dout = out[9:2];
+
+    // shift register, we shift out[7] on the right
+    // out[7] is the center column of the Automaton
+    reg [7:0] z = 0;
+
+    always @(posedge(clk))
+        if( ini == 0 ) z <= 8'h77;
+        else z <= { z[6:0], out[7]};
+
+    assign dout = z;
 
 endmodule
 
-module CA_cell(in, rule, out);
-    input wire[2:0] in;
+module CA_cell(i, rule, o);
+    input wire[2:0] i;
     input wire[7:0] rule;
+    output wire o;
 
-    output wire out;
-
-    assign out = rule[in];
+    assign o = rule[i];
 endmodule

--- a/verilog/assets/RAND.svg
+++ b/verilog/assets/RAND.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="979" height="1481">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="903" height="1935">
   <style>svg {
     stroke:#000;
     fill:none;
@@ -19,314 +19,337 @@
   .splitjoinBody {
     fill:#000;
   }</style>
-  <g s:type="inputExt" transform="translate(706,502)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">clk</text>
+  <g s:type="dff" transform="translate(786,1815)" s:width="30" s:height="40" id="cell_$procdff$19">
+    <s:alias val="$dff"/>
+    <s:alias val="$_DFF_"/>
+    <rect width="30" height="40" x="0" y="0" class="cell_$procdff$19"/>
+    <path d="M0,35 L5,30 L0,25" class="cell_$procdff$19"/>
+    <g s:x="30" s:y="10" s:pid="Q"/>
+    <g s:x="0" s:y="30" s:pid="CLK"/>
+    <g s:x="0" s:y="10" s:pid="D"/>
+  </g>
+  <g s:type="dff" transform="translate(851,1347)" s:width="30" s:height="40" id="cell_$procdff$20">
+    <s:alias val="$dff"/>
+    <s:alias val="$_DFF_"/>
+    <rect width="30" height="40" x="0" y="0" class="cell_$procdff$20"/>
+    <path d="M0,35 L5,30 L0,25" class="cell_$procdff$20"/>
+    <g s:x="30" s:y="10" s:pid="Q"/>
+    <g s:x="0" s:y="30" s:pid="CLK"/>
+    <g s:x="0" s:y="10" s:pid="D"/>
+  </g>
+  <g s:type="dff" transform="translate(650.3333333333334,1475)" s:width="30" s:height="40" id="cell_$procdff$21">
+    <s:alias val="$dff"/>
+    <s:alias val="$_DFF_"/>
+    <rect width="30" height="40" x="0" y="0" class="cell_$procdff$21"/>
+    <path d="M0,35 L5,30 L0,25" class="cell_$procdff$21"/>
+    <g s:x="30" s:y="10" s:pid="Q"/>
+    <g s:x="0" s:y="30" s:pid="CLK"/>
+    <g s:x="0" s:y="10" s:pid="D"/>
+  </g>
+  <g s:type="mux" transform="translate(724.3333333333334,1420)" s:width="20" s:height="40" id="cell_$procmux$11">
+    <s:alias val="$pmux"/>
+    <s:alias val="$mux"/>
+    <s:alias val="$_MUX_"/>
+    <path d="M0,0 L20,10 L20,30 L0,40 Z" class="cell_$procmux$11"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="0" s:y="30" s:pid="B"/>
+    <g s:x="10" s:y="35" s:pid="S"/>
+    <g s:x="20" s:y="20" s:pid="Y"/>
+  </g>
+  <g s:type="mux" transform="translate(724.3333333333334,1252.5)" s:width="20" s:height="40" id="cell_$procmux$14">
+    <s:alias val="$pmux"/>
+    <s:alias val="$mux"/>
+    <s:alias val="$_MUX_"/>
+    <path d="M0,0 L20,10 L20,30 L0,40 Z" class="cell_$procmux$14"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="0" s:y="30" s:pid="B"/>
+    <g s:x="10" s:y="35" s:pid="S"/>
+    <g s:x="20" s:y="20" s:pid="Y"/>
+  </g>
+  <g s:type="mux" transform="translate(789.3333333333334,1242.5)" s:width="20" s:height="40" id="cell_$procmux$17">
+    <s:alias val="$pmux"/>
+    <s:alias val="$mux"/>
+    <s:alias val="$_MUX_"/>
+    <path d="M0,0 L20,10 L20,30 L0,40 Z" class="cell_$procmux$17"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="0" s:y="30" s:pid="B"/>
+    <g s:x="10" s:y="35" s:pid="S"/>
+    <g s:x="20" s:y="20" s:pid="Y"/>
+  </g>
+  <g s:type="generic" transform="translate(398,133)" s:width="30" s:height="40" id="cell_automaton_cell[0].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[0].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[0].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[0].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[0].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[0].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[0].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[0].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[0].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(392,887.5)" s:width="30" s:height="40" id="cell_automaton_cell[10].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[10].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[10].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[10].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[10].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[10].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[10].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[10].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[10].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(392,975.5)" s:width="30" s:height="40" id="cell_automaton_cell[11].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[11].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[11].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[11].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[11].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[11].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[11].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[11].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[11].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(392,1063.5)" s:width="30" s:height="40" id="cell_automaton_cell[12].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[12].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[12].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[12].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[12].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[12].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[12].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[12].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[12].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(392,1239.5)" s:width="30" s:height="40" id="cell_automaton_cell[13].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[13].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[13].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[13].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[13].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[13].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[13].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[13].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[13].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(392,1151.5)" s:width="30" s:height="40" id="cell_automaton_cell[14].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[14].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[14].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[14].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[14].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[14].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[14].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[14].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[14].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,45)" s:width="30" s:height="40" id="cell_automaton_cell[1].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[1].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[1].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[1].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[1].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[1].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[1].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[1].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[1].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,221)" s:width="30" s:height="40" id="cell_automaton_cell[2].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[2].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[2].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[2].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[2].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[2].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[2].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[2].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[2].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,309)" s:width="30" s:height="40" id="cell_automaton_cell[3].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[3].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[3].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[3].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[3].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[3].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[3].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[3].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[3].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,397)" s:width="30" s:height="40" id="cell_automaton_cell[4].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[4].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[4].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[4].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[4].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[4].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[4].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[4].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[4].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,485)" s:width="30" s:height="40" id="cell_automaton_cell[5].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[5].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[5].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[5].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[5].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[5].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[5].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[5].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[5].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,573)" s:width="30" s:height="40" id="cell_automaton_cell[6].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[6].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[6].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[6].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[6].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[6].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[6].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[6].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[6].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,1552)" s:width="30" s:height="40" id="cell_automaton_cell[7].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[7].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[7].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[7].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[7].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[7].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[7].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[7].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[7].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,702.5)" s:width="30" s:height="40" id="cell_automaton_cell[8].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[8].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[8].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[8].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[8].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[8].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[8].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[8].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[8].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="generic" transform="translate(398,790.5)" s:width="30" s:height="40" id="cell_automaton_cell[9].ca_cell">
+    <text x="15" y="-4" class="nodelabel cell_automaton_cell[9].ca_cell" s:attribute="ref">CA_cell</text>
+    <rect width="30" height="40" s:generic="body" class="cell_automaton_cell[9].ca_cell"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[9].ca_cell~i">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[9].ca_cell">i</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0" id="port_automaton_cell[9].ca_cell~rule">
+      <text x="-3" y="-4" class="inputPortLabel cell_automaton_cell[9].ca_cell">rule</text>
+    </g>
+    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0" id="port_automaton_cell[9].ca_cell~o">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="cell_automaton_cell[9].ca_cell">o</text>
+    </g>
+  </g>
+  <g s:type="inputExt" transform="translate(392,1835)" s:width="30" s:height="20" id="cell_clk">
+    <text x="15" y="-4" class="nodelabel cell_clk" s:attribute="ref">clk</text>
     <s:alias val="$_inputExt_"/>
-    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_clk"/>
     <g s:x="28" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="inputExt" transform="translate(63,16)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">addr</text>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_addr">
+    <text x="15" y="-4" class="nodelabel cell_addr" s:attribute="ref">addr</text>
     <s:alias val="$_inputExt_"/>
-    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_addr"/>
     <g s:x="28" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="inputExt" transform="translate(706,388)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">write_en</text>
+  <g s:type="inputExt" transform="translate(638,1347)" s:width="30" s:height="20" id="cell_write_en">
+    <text x="15" y="-4" class="nodelabel cell_write_en" s:attribute="ref">write_en</text>
     <s:alias val="$_inputExt_"/>
-    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_write_en"/>
     <g s:x="28" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="inputExt" transform="translate(12,16)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">rst</text>
+  <g s:type="inputExt" transform="translate(54,22)" s:width="30" s:height="20" id="cell_rst">
+    <text x="15" y="-4" class="nodelabel cell_rst" s:attribute="ref">rst</text>
     <s:alias val="$_inputExt_"/>
-    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_rst"/>
     <g s:x="28" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="inputExt" transform="translate(549,1394)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">din</text>
+  <g s:type="inputExt" transform="translate(392,1640)" s:width="30" s:height="20" id="cell_din">
+    <text x="15" y="-4" class="nodelabel cell_din" s:attribute="ref">din</text>
     <s:alias val="$_inputExt_"/>
-    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_din"/>
     <g s:x="28" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="outputExt" transform="translate(915,592.5)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">dout</text>
+  <g s:type="outputExt" transform="translate(851,1815)" s:width="30" s:height="20" id="cell_dout">
+    <text x="15" y="-4" class="nodelabel cell_dout" s:attribute="ref">dout</text>
     <s:alias val="$_outputExt_"/>
-    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_dout"/>
     <g s:x="0" s:y="10" s:pid="A"/>
   </g>
-  <g s:type="dff" transform="translate(915,33)" s:width="30" s:height="40">
-    <s:alias val="$dff"/>
-    <s:alias val="$_DFF_"/>
-    <rect width="30" height="40" x="0" y="0"/>
-    <path d="M0,35 L5,30 L0,25"/>
-    <g s:x="30" s:y="10" s:pid="Q"/>
-    <g s:x="0" s:y="30" s:pid="CLK"/>
-    <g s:x="0" s:y="10" s:pid="D"/>
-  </g>
-  <g s:type="dff" transform="translate(795,443)" s:width="30" s:height="40">
-    <s:alias val="$dff"/>
-    <s:alias val="$_DFF_"/>
-    <rect width="30" height="40" x="0" y="0"/>
-    <path d="M0,35 L5,30 L0,25"/>
-    <g s:x="30" s:y="10" s:pid="Q"/>
-    <g s:x="0" s:y="30" s:pid="CLK"/>
-    <g s:x="0" s:y="10" s:pid="D"/>
-  </g>
-  <g s:type="mux" transform="translate(860,23)" s:width="20" s:height="40">
-    <s:alias val="$pmux"/>
-    <s:alias val="$mux"/>
-    <s:alias val="$_MUX_"/>
-    <path d="M0,0 L20,10 L20,30 L0,40 Z"/>
-    <g s:x="0" s:y="10" s:pid="A"/>
-    <g s:x="0" s:y="30" s:pid="B"/>
-    <g s:x="10" s:y="35" s:pid="S"/>
-    <g s:x="20" s:y="20" s:pid="Y"/>
-  </g>
-  <g s:type="mux" transform="translate(798.3333333333334,117.5)" s:width="20" s:height="40">
-    <s:alias val="$pmux"/>
-    <s:alias val="$mux"/>
-    <s:alias val="$_MUX_"/>
-    <path d="M0,0 L20,10 L20,30 L0,40 Z"/>
-    <g s:x="0" s:y="10" s:pid="A"/>
-    <g s:x="0" s:y="30" s:pid="B"/>
-    <g s:x="10" s:y="35" s:pid="S"/>
-    <g s:x="20" s:y="20" s:pid="Y"/>
-  </g>
-  <g s:type="generic" transform="translate(549,45)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(549,209)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(549,291)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(549,373)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(549,455)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(549,1230)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(549,1312)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(549,127)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,520)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,602)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,684)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,814)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,896)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,978)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,1060)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="generic" transform="translate(407,1142)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">CA_cell</text>
-    <rect width="30" height="40" s:generic="body"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">in</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">rule</text>
-    </g>
-    <g transform="translate(30,10)" s:x="30" s:y="10" s:pid="out0">
-      <text x="5" y="-4" style="fill:#000; stroke:none">out</text>
-    </g>
-  </g>
-  <g s:type="constant" transform="translate(706,443)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">1</text>
+  <g s:type="constant" transform="translate(392,1770)" s:width="30" s:height="20" id="cell_1">
+    <text x="15" y="-4" class="nodelabel cell_1" s:attribute="ref">1</text>
     <s:alias val="$_constant_"/>
-    <rect width="30" height="20"/>
+    <rect width="30" height="20" class="cell_1"/>
     <g s:x="30" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="constant" transform="translate(795,23)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">0x177</text>
+  <g s:type="constant" transform="translate(638,1420)" s:width="30" s:height="20" id="cell_01110111">
+    <text x="15" y="-4" class="nodelabel cell_01110111" s:attribute="ref">0x77</text>
     <s:alias val="$_constant_"/>
-    <rect width="30" height="20"/>
+    <rect width="30" height="20" class="cell_01110111"/>
     <g s:x="30" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="constant" transform="translate(549,1449)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">0x1</text>
+  <g s:type="constant" transform="translate(392,1705)" s:width="30" s:height="20" id="cell_0000001">
+    <text x="15" y="-4" class="nodelabel cell_0000001" s:attribute="ref">0x1</text>
     <s:alias val="$_constant_"/>
-    <rect width="30" height="20"/>
+    <rect width="30" height="20" class="cell_0000001"/>
     <g s:x="30" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="constant" transform="translate(317,749)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel" s:attribute="ref">0x1e</text>
+  <g s:type="constant" transform="translate(721,1197.5)" s:width="30" s:height="20" id="cell_000000101110111">
+    <text x="15" y="-4" class="nodelabel cell_000000101110111" s:attribute="ref">0x177</text>
     <s:alias val="$_constant_"/>
-    <rect width="30" height="20"/>
+    <rect width="30" height="20" class="cell_000000101110111"/>
     <g s:x="30" s:y="10" s:pid="Y"/>
   </g>
-  <g s:type="join" transform="translate(553,582)" s:width="4" s:height="40">
-    <rect width="5" height="160" class="splitjoinBody" s:generic="body"/>
+  <g s:type="constant" transform="translate(302,723)" s:width="30" s:height="20" id="cell_00011110">
+    <text x="15" y="-4" class="nodelabel cell_00011110" s:attribute="ref">0x1e</text>
+    <s:alias val="$_constant_"/>
+    <rect width="30" height="20" class="cell_00011110"/>
+    <g s:x="30" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="join" transform="translate(659,1552)" s:width="4" s:height="40" id="cell_$join$,68,21,22,23,24,25,26,27,">
+    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
+    <s:alias val="$_join_"/>
+    <g s:x="5" s:y="20" s:pid="out"/>
+    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel">0</text>
+    </g>
+    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel">1:7</text>
+    </g>
+  </g>
+  <g s:type="join" transform="translate(657.5,542.5)" s:width="4" s:height="40" id="cell_$join$,69,70,71,72,73,74,75,68,76,77,78,79,80,81,82,">
+    <rect width="5" height="300" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
     <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
@@ -353,40 +376,29 @@
     <g transform="translate(0,150)" s:x="0" s:y="10" s:pid="in0">
       <text x="-3" y="-4" class="inputPortLabel">7</text>
     </g>
-  </g>
-  <g s:type="join" transform="translate(726.5,107)" s:width="4" s:height="40">
-    <rect width="5" height="180" class="splitjoinBody" s:generic="body"/>
-    <s:alias val="$_join_"/>
-    <g s:x="5" s:y="20" s:pid="out"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">0</text>
+    <g transform="translate(0,170)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel">8</text>
     </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">1</text>
+    <g transform="translate(0,190)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel">9</text>
     </g>
-    <g transform="translate(0,50)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">2:9</text>
-    </g>
-    <g transform="translate(0,70)" s:x="0" s:y="10" s:pid="in0">
+    <g transform="translate(0,210)" s:x="0" s:y="10" s:pid="in0">
       <text x="-3" y="-4" class="inputPortLabel">10</text>
     </g>
-    <g transform="translate(0,90)" s:x="0" s:y="10" s:pid="in0">
+    <g transform="translate(0,230)" s:x="0" s:y="10" s:pid="in0">
       <text x="-3" y="-4" class="inputPortLabel">11</text>
     </g>
-    <g transform="translate(0,110)" s:x="0" s:y="10" s:pid="in0">
+    <g transform="translate(0,250)" s:x="0" s:y="10" s:pid="in0">
       <text x="-3" y="-4" class="inputPortLabel">12</text>
     </g>
-    <g transform="translate(0,130)" s:x="0" s:y="10" s:pid="in0">
+    <g transform="translate(0,270)" s:x="0" s:y="10" s:pid="in0">
       <text x="-3" y="-4" class="inputPortLabel">13</text>
     </g>
-    <g transform="translate(0,150)" s:x="0" s:y="10" s:pid="in0">
+    <g transform="translate(0,290)" s:x="0" s:y="10" s:pid="in0">
       <text x="-3" y="-4" class="inputPortLabel">14</text>
     </g>
-    <g transform="translate(0,170)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">15</text>
-    </g>
   </g>
-  <g s:type="join" transform="translate(729,309)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(659,1262)" s:width="4" s:height="40" id="cell_$join$,13,14,15,16,17,18,19,20,107,108,109,110,111,112,113,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -394,10 +406,10 @@
       <text x="-3" y="-4" class="inputPortLabel">0:7</text>
     </g>
     <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">8:15</text>
+      <text x="-3" y="-4" class="inputPortLabel">8:14</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(421,35)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,123)" s:width="4" s:height="40" id="cell_$join$,53,52,66,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -405,7 +417,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(332,25)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,113)" s:width="4" s:height="40" id="cell_$join$,53,52,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -416,7 +428,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(421,199)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,877.5)" s:width="4" s:height="40" id="cell_$join$,63,62,61,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -424,7 +436,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(332,189)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,867.5)" s:width="4" s:height="40" id="cell_$join$,63,62,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -435,7 +447,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(421,281)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,965.5)" s:width="4" s:height="40" id="cell_$join$,64,63,62,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -443,7 +455,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(332,271)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,955.5)" s:width="4" s:height="40" id="cell_$join$,64,63,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -454,7 +466,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(421,363)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,1053.5)" s:width="4" s:height="40" id="cell_$join$,65,64,63,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -462,7 +474,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(332,353)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,1043.5)" s:width="4" s:height="40" id="cell_$join$,65,64,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -473,7 +485,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(421,445)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,1229.5)" s:width="4" s:height="40" id="cell_$join$,66,65,64,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -481,7 +493,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(332,435)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,1219.5)" s:width="4" s:height="40" id="cell_$join$,66,65,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -492,26 +504,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(421,1220)" s:width="4" s:height="40">
-    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
-    <s:alias val="$_join_"/>
-    <g s:x="5" s:y="20" s:pid="out"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">0:1</text>
-    </g>
-  </g>
-  <g s:type="join" transform="translate(332,1210)" s:width="4" s:height="40">
-    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
-    <s:alias val="$_join_"/>
-    <g s:x="5" s:y="20" s:pid="out"/>
-    <g transform="translate(0,10)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">0</text>
-    </g>
-    <g transform="translate(0,30)" s:x="0" s:y="10" s:pid="in0">
-      <text x="-3" y="-4" class="inputPortLabel">1</text>
-    </g>
-  </g>
-  <g s:type="join" transform="translate(416.3333333333333,1302)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(317,1141.5)" s:width="4" s:height="40" id="cell_$join$,52,66,65,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -522,7 +515,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1:2</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(421,117)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,35)" s:width="4" s:height="40" id="cell_$join$,54,53,52,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -530,7 +523,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(332,107)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,25)" s:width="4" s:height="40" id="cell_$join$,54,53,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -541,7 +534,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(336,510)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,211)" s:width="4" s:height="40" id="cell_$join$,55,54,53,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -549,7 +542,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(276,500)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,201)" s:width="4" s:height="40" id="cell_$join$,55,54,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -560,7 +553,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(336,592)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,299)" s:width="4" s:height="40" id="cell_$join$,56,55,54,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -568,7 +561,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(276,582)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,289)" s:width="4" s:height="40" id="cell_$join$,56,55,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -579,7 +572,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(336,674)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,387)" s:width="4" s:height="40" id="cell_$join$,57,56,55,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -587,7 +580,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(276,664)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,377)" s:width="4" s:height="40" id="cell_$join$,57,56,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -598,7 +591,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(336,804)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,475)" s:width="4" s:height="40" id="cell_$join$,58,57,56,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -606,7 +599,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(276,794)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,465)" s:width="4" s:height="40" id="cell_$join$,58,57,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -617,7 +610,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(336,886)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,563)" s:width="4" s:height="40" id="cell_$join$,59,58,57,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -625,7 +618,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(276,876)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,553)" s:width="4" s:height="40" id="cell_$join$,59,58,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -636,7 +629,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(336,968)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,1542)" s:width="4" s:height="40" id="cell_$join$,60,59,58,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -644,7 +637,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(276,958)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,1532)" s:width="4" s:height="40" id="cell_$join$,60,59,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -655,7 +648,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(336,1050)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(321,638)" s:width="4" s:height="40" id="cell_$join$,61,60,59,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -663,7 +656,7 @@
       <text x="-3" y="-4" class="inputPortLabel">0:1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(276,1155.5)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(261,790.5)" s:width="4" s:height="40" id="cell_$join$,61,60,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -674,7 +667,7 @@
       <text x="-3" y="-4" class="inputPortLabel">1</text>
     </g>
   </g>
-  <g s:type="join" transform="translate(332,1132)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(317,780.5)" s:width="4" s:height="40" id="cell_$join$,62,61,60,">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20" s:pid="out"/>
@@ -685,8 +678,16 @@
       <text x="-3" y="-4" class="inputPortLabel">1:2</text>
     </g>
   </g>
-  <g s:type="split" transform="translate(117,422)" s:width="5" s:height="40">
-    <rect width="5" height="320" class="splitjoinBody" s:generic="body"/>
+  <g s:type="split" transform="translate(417,1890)" s:width="5" s:height="40" id="cell_$split$,21,22,23,24,25,26,27,28,">
+    <rect width="5" height="20" class="splitjoinBody" s:generic="body"/>
+    <s:alias val="$_split_"/>
+    <g s:x="0" s:y="20" s:pid="in"/>
+    <g transform="translate(4,10)" s:x="4" s:y="10" s:pid="out0">
+      <text x="5" y="-4">0:6</text>
+    </g>
+  </g>
+  <g s:type="split" transform="translate(99,1139.5)" s:width="5" s:height="40" id="cell_$split$,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,">
+    <rect width="5" height="300" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_split_"/>
     <g s:x="0" s:y="20" s:pid="in"/>
     <g transform="translate(4,10)" s:x="4" s:y="10" s:pid="out0">
@@ -711,331 +712,321 @@
       <text x="5" y="-4">14</text>
     </g>
     <g transform="translate(4,150)" s:x="4" s:y="10" s:pid="out0">
-      <text x="5" y="-4">15</text>
-    </g>
-    <g transform="translate(4,170)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">2</text>
     </g>
-    <g transform="translate(4,190)" s:x="4" s:y="10" s:pid="out0">
+    <g transform="translate(4,170)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">3</text>
     </g>
-    <g transform="translate(4,210)" s:x="4" s:y="10" s:pid="out0">
+    <g transform="translate(4,190)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">4</text>
     </g>
-    <g transform="translate(4,230)" s:x="4" s:y="10" s:pid="out0">
+    <g transform="translate(4,210)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">5</text>
     </g>
-    <g transform="translate(4,250)" s:x="4" s:y="10" s:pid="out0">
+    <g transform="translate(4,230)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">6</text>
     </g>
-    <g transform="translate(4,270)" s:x="4" s:y="10" s:pid="out0">
+    <g transform="translate(4,250)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">7</text>
     </g>
-    <g transform="translate(4,290)" s:x="4" s:y="10" s:pid="out0">
+    <g transform="translate(4,270)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">8</text>
     </g>
-    <g transform="translate(4,310)" s:x="4" s:y="10" s:pid="out0">
+    <g transform="translate(4,290)" s:x="4" s:y="10" s:pid="out0">
       <text x="5" y="-4">9</text>
     </g>
   </g>
-  <line x1="559" y1="602.5" x2="915" y2="602.5"/>
-  <line x1="559" y1="602.5" x2="626" y2="602.5"/>
-  <line x1="626" y1="602.5" x2="626" y2="157.5"/>
-  <circle cx="626" cy="602.5" r="2" style="fill:#000"/>
-  <line x1="626" y1="157.5" x2="726.5" y2="157.5"/>
-  <line x1="734" y1="512" x2="770" y2="512"/>
-  <line x1="770" y1="512" x2="770" y2="408"/>
-  <line x1="770" y1="408" x2="890" y2="408"/>
-  <line x1="890" y1="408" x2="890" y2="63"/>
-  <line x1="890" y1="63" x2="915" y2="63"/>
-  <line x1="734" y1="512" x2="770" y2="512"/>
-  <line x1="770" y1="512" x2="770" y2="473"/>
-  <circle cx="770" cy="473" r="2" style="fill:#000"/>
-  <line x1="770" y1="473" x2="795" y2="473"/>
-  <line x1="880" y1="43" x2="915" y2="43"/>
-  <line x1="736" y1="453" x2="795" y2="453"/>
-  <line x1="825" y1="33" x2="860" y2="33"/>
-  <line x1="818.3333333333334" y1="137.5" x2="835" y2="137.5"/>
-  <line x1="835" y1="137.5" x2="835" y2="53"/>
-  <line x1="835" y1="53" x2="860" y2="53"/>
-  <line x1="825" y1="453" x2="870" y2="453"/>
-  <line x1="870" y1="453" x2="870" y2="58"/>
-  <line x1="732.5" y1="127.5" x2="798.3333333333334" y2="127.5"/>
-  <line x1="735" y1="329.5" x2="770" y2="329.5"/>
-  <line x1="770" y1="329.5" x2="770" y2="147.5"/>
-  <line x1="770" y1="147.5" x2="798.3333333333334" y2="147.5"/>
-  <line x1="734" y1="398" x2="808.3333333333334" y2="398"/>
-  <line x1="808.3333333333334" y1="398" x2="808.3333333333334" y2="152.5"/>
-  <line x1="427" y1="55.5" x2="549" y2="55.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="85"/>
-  <line x1="367" y1="85" x2="474" y2="85"/>
-  <line x1="474" y1="85" x2="474" y2="75.5"/>
-  <circle cx="367" cy="759" r="2" style="fill:#000"/>
-  <line x1="474" y1="75.5" x2="549" y2="75.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="249"/>
-  <line x1="367" y1="249" x2="474" y2="249"/>
-  <line x1="474" y1="249" x2="474" y2="239.5"/>
-  <circle cx="367" cy="249" r="2" style="fill:#000"/>
-  <line x1="474" y1="239.5" x2="549" y2="239.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="331"/>
-  <line x1="367" y1="331" x2="474" y2="331"/>
-  <line x1="474" y1="331" x2="474" y2="321.5"/>
-  <circle cx="367" cy="331" r="2" style="fill:#000"/>
-  <line x1="474" y1="321.5" x2="549" y2="321.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="413"/>
-  <line x1="367" y1="413" x2="474" y2="413"/>
-  <line x1="474" y1="413" x2="474" y2="403.5"/>
-  <circle cx="367" cy="413" r="2" style="fill:#000"/>
-  <line x1="474" y1="403.5" x2="549" y2="403.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="495"/>
-  <line x1="367" y1="495" x2="474" y2="495"/>
-  <line x1="474" y1="495" x2="474" y2="485.5"/>
-  <circle cx="367" cy="495" r="2" style="fill:#000"/>
-  <line x1="474" y1="485.5" x2="549" y2="485.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="1270"/>
-  <line x1="367" y1="1270" x2="474" y2="1270"/>
-  <line x1="474" y1="1270" x2="474" y2="1260.5"/>
-  <circle cx="367" cy="1270" r="2" style="fill:#000"/>
-  <line x1="474" y1="1260.5" x2="549" y2="1260.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="1352"/>
-  <line x1="367" y1="1352" x2="474" y2="1352"/>
-  <line x1="474" y1="1352" x2="474" y2="1342.5"/>
-  <line x1="474" y1="1342.5" x2="549" y2="1342.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="167"/>
-  <line x1="367" y1="167" x2="474" y2="167"/>
-  <line x1="474" y1="167" x2="474" y2="157.5"/>
-  <circle cx="367" cy="167" r="2" style="fill:#000"/>
-  <line x1="474" y1="157.5" x2="549" y2="157.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="550.5"/>
-  <circle cx="367" cy="550.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="550.5" x2="407" y2="550.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="632.5"/>
-  <circle cx="367" cy="632.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="632.5" x2="407" y2="632.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="714.5"/>
-  <circle cx="367" cy="714.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="714.5" x2="407" y2="714.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="844.5"/>
-  <circle cx="367" cy="844.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="844.5" x2="407" y2="844.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="926.5"/>
-  <circle cx="367" cy="926.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="926.5" x2="407" y2="926.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="1008.5"/>
-  <circle cx="367" cy="1008.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="1008.5" x2="407" y2="1008.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="1090.5"/>
-  <circle cx="367" cy="1090.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="1090.5" x2="407" y2="1090.5"/>
-  <line x1="347" y1="759" x2="367" y2="759"/>
-  <line x1="367" y1="759" x2="367" y2="1172.5"/>
-  <circle cx="367" cy="1172.5" r="2" style="fill:#000"/>
-  <line x1="367" y1="1172.5" x2="407" y2="1172.5"/>
-  <line x1="427" y1="219.5" x2="549" y2="219.5"/>
-  <line x1="427" y1="301.5" x2="549" y2="301.5"/>
-  <line x1="427" y1="383.5" x2="549" y2="383.5"/>
-  <line x1="427" y1="465.5" x2="549" y2="465.5"/>
-  <line x1="427" y1="1240.5" x2="549" y2="1240.5"/>
-  <line x1="422.3333333333333" y1="1322.5" x2="549" y2="1322.5"/>
-  <line x1="427" y1="137.5" x2="549" y2="137.5"/>
-  <line x1="342" y1="530.5" x2="407" y2="530.5"/>
-  <line x1="342" y1="612.5" x2="407" y2="612.5"/>
-  <line x1="342" y1="694.5" x2="407" y2="694.5"/>
-  <line x1="342" y1="824.5" x2="407" y2="824.5"/>
-  <line x1="342" y1="906.5" x2="407" y2="906.5"/>
-  <line x1="342" y1="988.5" x2="407" y2="988.5"/>
-  <line x1="342" y1="1070.5" x2="407" y2="1070.5"/>
-  <line x1="338" y1="1152.5" x2="407" y2="1152.5"/>
-  <line x1="438" y1="530.5" x2="553.5" y2="530.5"/>
-  <line x1="553.5" y1="530.5" x2="553.5" y2="592"/>
-  <line x1="438" y1="612.5" x2="553" y2="612.5"/>
-  <line x1="438" y1="694.5" x2="474" y2="694.5"/>
-  <line x1="474" y1="694.5" x2="474" y2="632.5"/>
-  <line x1="474" y1="632.5" x2="553" y2="632.5"/>
-  <line x1="438" y1="824.5" x2="484" y2="824.5"/>
-  <line x1="484" y1="824.5" x2="484" y2="652.5"/>
-  <line x1="484" y1="652.5" x2="553" y2="652.5"/>
-  <line x1="438" y1="906.5" x2="494" y2="906.5"/>
-  <line x1="494" y1="906.5" x2="494" y2="672.5"/>
-  <line x1="494" y1="672.5" x2="553" y2="672.5"/>
-  <line x1="438" y1="988.5" x2="504" y2="988.5"/>
-  <line x1="504" y1="988.5" x2="504" y2="692.5"/>
-  <line x1="504" y1="692.5" x2="553" y2="692.5"/>
-  <line x1="438" y1="1070.5" x2="514" y2="1070.5"/>
-  <line x1="514" y1="1070.5" x2="514" y2="712.5"/>
-  <line x1="514" y1="712.5" x2="553" y2="712.5"/>
-  <line x1="438" y1="1152.5" x2="553.5" y2="1152.5"/>
-  <line x1="553.5" y1="1152.5" x2="553.5" y2="733"/>
-  <line x1="580" y1="55.5" x2="727" y2="55.5"/>
-  <line x1="727" y1="55.5" x2="727" y2="117"/>
-  <line x1="580" y1="137.5" x2="726.5" y2="137.5"/>
-  <line x1="580" y1="219.5" x2="616" y2="219.5"/>
-  <line x1="616" y1="219.5" x2="616" y2="177.5"/>
-  <line x1="616" y1="177.5" x2="726.5" y2="177.5"/>
-  <line x1="580" y1="301.5" x2="636" y2="301.5"/>
-  <line x1="636" y1="301.5" x2="636" y2="197.5"/>
-  <line x1="636" y1="197.5" x2="726.5" y2="197.5"/>
-  <line x1="580" y1="383.5" x2="646" y2="383.5"/>
-  <line x1="646" y1="383.5" x2="646" y2="217.5"/>
-  <line x1="646" y1="217.5" x2="726.5" y2="217.5"/>
-  <line x1="580" y1="465.5" x2="656" y2="465.5"/>
-  <line x1="656" y1="465.5" x2="656" y2="237.5"/>
-  <line x1="656" y1="237.5" x2="726.5" y2="237.5"/>
-  <line x1="580" y1="1240.5" x2="666" y2="1240.5"/>
-  <line x1="666" y1="1240.5" x2="666" y2="257.5"/>
-  <line x1="666" y1="257.5" x2="726.5" y2="257.5"/>
-  <line x1="580" y1="1322.5" x2="676" y2="1322.5"/>
-  <line x1="676" y1="1322.5" x2="676" y2="297"/>
-  <line x1="676" y1="297" x2="727" y2="297"/>
-  <line x1="727" y1="297" x2="727" y2="278"/>
-  <line x1="577" y1="1404" x2="686" y2="1404"/>
-  <line x1="686" y1="1404" x2="686" y2="319.5"/>
-  <line x1="686" y1="319.5" x2="729" y2="319.5"/>
-  <line x1="579" y1="1459" x2="696" y2="1459"/>
-  <line x1="696" y1="1459" x2="696" y2="339.5"/>
-  <line x1="696" y1="339.5" x2="729" y2="339.5"/>
-  <line x1="338" y1="45.5" x2="421" y2="45.5"/>
-  <line x1="121.5" y1="432" x2="121.5" y2="35.5"/>
-  <line x1="121.5" y1="35.5" x2="332" y2="35.5"/>
-  <line x1="121.5" y1="432" x2="121.5" y2="35.5"/>
-  <line x1="121.5" y1="35.5" x2="169" y2="35.5"/>
-  <line x1="169" y1="35.5" x2="169" y2="137.5"/>
-  <circle cx="169" cy="35.5" r="2" style="fill:#000"/>
-  <line x1="169" y1="137.5" x2="332" y2="137.5"/>
-  <line x1="121.5" y1="452" x2="121.5" y2="55.5"/>
-  <line x1="121.5" y1="55.5" x2="332" y2="55.5"/>
-  <line x1="121.5" y1="452" x2="121.5" y2="55.5"/>
-  <line x1="121.5" y1="55.5" x2="139" y2="55.5"/>
-  <line x1="139" y1="55.5" x2="139" y2="1312.5"/>
-  <circle cx="139" cy="55.5" r="2" style="fill:#000"/>
-  <line x1="139" y1="1312.5" x2="416.3333333333333" y2="1312.5"/>
-  <line x1="338" y1="209.5" x2="421" y2="209.5"/>
-  <line x1="122" y1="472.5" x2="169" y2="472.5"/>
-  <line x1="169" y1="472.5" x2="169" y2="199.5"/>
-  <line x1="169" y1="199.5" x2="332" y2="199.5"/>
-  <line x1="122" y1="472.5" x2="169" y2="472.5"/>
-  <line x1="169" y1="472.5" x2="169" y2="301.5"/>
-  <circle cx="169" cy="301.5" r="2" style="fill:#000"/>
-  <line x1="169" y1="301.5" x2="332" y2="301.5"/>
-  <line x1="122" y1="492.5" x2="179" y2="492.5"/>
-  <line x1="179" y1="492.5" x2="179" y2="219.5"/>
-  <circle cx="179" cy="492.5" r="2" style="fill:#000"/>
-  <line x1="179" y1="219.5" x2="332" y2="219.5"/>
-  <line x1="122" y1="492.5" x2="179" y2="492.5"/>
-  <line x1="179" y1="492.5" x2="179" y2="1142.5"/>
-  <line x1="179" y1="1142.5" x2="332" y2="1142.5"/>
-  <line x1="338" y1="291.5" x2="421" y2="291.5"/>
-  <line x1="122" y1="512.5" x2="189" y2="512.5"/>
-  <line x1="189" y1="512.5" x2="189" y2="281.5"/>
-  <line x1="189" y1="281.5" x2="332" y2="281.5"/>
-  <line x1="122" y1="512.5" x2="189" y2="512.5"/>
-  <line x1="189" y1="512.5" x2="189" y2="383.5"/>
-  <circle cx="189" cy="383.5" r="2" style="fill:#000"/>
-  <line x1="189" y1="383.5" x2="332" y2="383.5"/>
-  <line x1="338" y1="373.5" x2="421" y2="373.5"/>
-  <line x1="122" y1="532.5" x2="199" y2="532.5"/>
-  <line x1="199" y1="532.5" x2="199" y2="363.5"/>
-  <line x1="199" y1="363.5" x2="332" y2="363.5"/>
-  <line x1="122" y1="532.5" x2="199" y2="532.5"/>
-  <line x1="199" y1="532.5" x2="199" y2="465.5"/>
-  <circle cx="199" cy="465.5" r="2" style="fill:#000"/>
-  <line x1="199" y1="465.5" x2="332" y2="465.5"/>
-  <line x1="338" y1="455.5" x2="421" y2="455.5"/>
-  <line x1="122" y1="552.5" x2="209" y2="552.5"/>
-  <line x1="209" y1="552.5" x2="209" y2="445.5"/>
-  <circle cx="209" cy="552.5" r="2" style="fill:#000"/>
-  <line x1="209" y1="445.5" x2="332" y2="445.5"/>
-  <line x1="122" y1="552.5" x2="209" y2="552.5"/>
-  <line x1="209" y1="552.5" x2="209" y2="1240.5"/>
-  <line x1="209" y1="1240.5" x2="332" y2="1240.5"/>
-  <line x1="338" y1="1230.5" x2="421" y2="1230.5"/>
-  <line x1="338" y1="1230.5" x2="357" y2="1230.5"/>
-  <line x1="357" y1="1230.5" x2="357" y2="1332.5"/>
-  <circle cx="357" cy="1230.5" r="2" style="fill:#000"/>
-  <line x1="357" y1="1332.5" x2="416.3333333333333" y2="1332.5"/>
-  <line x1="122" y1="572.5" x2="149" y2="572.5"/>
-  <line x1="149" y1="572.5" x2="149" y2="1220.5"/>
-  <line x1="149" y1="1220.5" x2="332" y2="1220.5"/>
-  <line x1="338" y1="127.5" x2="421" y2="127.5"/>
-  <line x1="122" y1="592.5" x2="159" y2="592.5"/>
-  <line x1="159" y1="592.5" x2="159" y2="117.5"/>
-  <line x1="159" y1="117.5" x2="332" y2="117.5"/>
-  <line x1="122" y1="592.5" x2="159" y2="592.5"/>
-  <line x1="159" y1="592.5" x2="159" y2="530.5"/>
-  <circle cx="159" cy="530.5" r="2" style="fill:#000"/>
-  <line x1="159" y1="530.5" x2="276" y2="530.5"/>
-  <line x1="282" y1="520.5" x2="336" y2="520.5"/>
-  <line x1="122" y1="612.5" x2="219" y2="612.5"/>
-  <line x1="219" y1="612.5" x2="219" y2="510.5"/>
-  <circle cx="219" cy="612.5" r="2" style="fill:#000"/>
-  <line x1="219" y1="510.5" x2="276" y2="510.5"/>
-  <line x1="122" y1="612.5" x2="276" y2="612.5"/>
-  <line x1="282" y1="602.5" x2="336" y2="602.5"/>
-  <line x1="122" y1="632.5" x2="259" y2="632.5"/>
-  <line x1="259" y1="632.5" x2="259" y2="592.5"/>
-  <circle cx="259" cy="632.5" r="2" style="fill:#000"/>
-  <line x1="259" y1="592.5" x2="276" y2="592.5"/>
-  <line x1="122" y1="632.5" x2="259" y2="632.5"/>
-  <line x1="259" y1="632.5" x2="259" y2="694.5"/>
-  <line x1="259" y1="694.5" x2="276" y2="694.5"/>
-  <line x1="282" y1="684.5" x2="336" y2="684.5"/>
-  <line x1="122" y1="652.5" x2="249" y2="652.5"/>
-  <line x1="249" y1="652.5" x2="249" y2="674.5"/>
-  <circle cx="249" cy="674.5" r="2" style="fill:#000"/>
-  <line x1="249" y1="674.5" x2="276" y2="674.5"/>
-  <line x1="122" y1="652.5" x2="249" y2="652.5"/>
-  <line x1="249" y1="652.5" x2="249" y2="824.5"/>
-  <line x1="249" y1="824.5" x2="276" y2="824.5"/>
-  <line x1="282" y1="814.5" x2="336" y2="814.5"/>
-  <line x1="122" y1="672.5" x2="239" y2="672.5"/>
-  <line x1="239" y1="672.5" x2="239" y2="804.5"/>
-  <circle cx="239" cy="804.5" r="2" style="fill:#000"/>
-  <line x1="239" y1="804.5" x2="276" y2="804.5"/>
-  <line x1="122" y1="672.5" x2="239" y2="672.5"/>
-  <line x1="239" y1="672.5" x2="239" y2="906.5"/>
-  <line x1="239" y1="906.5" x2="276" y2="906.5"/>
-  <line x1="282" y1="896.5" x2="336" y2="896.5"/>
-  <line x1="122" y1="692.5" x2="229" y2="692.5"/>
-  <line x1="229" y1="692.5" x2="229" y2="886.5"/>
-  <circle cx="229" cy="886.5" r="2" style="fill:#000"/>
-  <line x1="229" y1="886.5" x2="276" y2="886.5"/>
-  <line x1="122" y1="692.5" x2="229" y2="692.5"/>
-  <line x1="229" y1="692.5" x2="229" y2="988.5"/>
-  <line x1="229" y1="988.5" x2="276" y2="988.5"/>
-  <line x1="282" y1="978.5" x2="336" y2="978.5"/>
-  <line x1="121.5" y1="713" x2="121.5" y2="968.5"/>
-  <line x1="121.5" y1="968.5" x2="276" y2="968.5"/>
-  <line x1="121.5" y1="713" x2="121.5" y2="968.5"/>
-  <line x1="121.5" y1="968.5" x2="219" y2="968.5"/>
-  <line x1="219" y1="968.5" x2="219" y2="1186"/>
-  <circle cx="219" cy="968.5" r="2" style="fill:#000"/>
-  <line x1="219" y1="1186" x2="276" y2="1186"/>
-  <line x1="282" y1="1176" x2="292" y2="1176"/>
-  <line x1="292" y1="1176" x2="292" y2="1060.5"/>
-  <line x1="292" y1="1060.5" x2="336" y2="1060.5"/>
-  <line x1="282" y1="1176" x2="292" y2="1176"/>
-  <line x1="292" y1="1176" x2="292" y2="1162.5"/>
-  <circle cx="292" cy="1162.5" r="2" style="fill:#000"/>
-  <line x1="292" y1="1162.5" x2="332" y2="1162.5"/>
-  <line x1="121.5" y1="733" x2="121.5" y2="1166"/>
-  <line x1="121.5" y1="1166" x2="276" y2="1166"/>
-  <line x1="945" y1="43" x2="967" y2="43"/>
-  <line x1="967" y1="43" x2="967" y2="12"/>
-  <line x1="967" y1="12" x2="117.5" y2="12"/>
-  <line x1="117.5" y1="12" x2="117.5" y2="442"/>
+  <line x1="420" x2="786" y1="1845" y2="1845" class="net_2"/>
+  <line x1="420" x2="608" y1="1845" y2="1845" class="net_2"/>
+  <line x1="608" x2="608" y1="1845" y2="1377" class="net_2"/>
+  <circle cx="608" cy="1845" r="2" style="fill:#000" class="net_2"/>
+  <line x1="608" x2="851" y1="1377" y2="1377" class="net_2"/>
+  <line x1="420" x2="608" y1="1845" y2="1845" class="net_2"/>
+  <line x1="608" x2="608" y1="1845" y2="1505" class="net_2"/>
+  <circle cx="608" cy="1505" r="2" style="fill:#000" class="net_2"/>
+  <line x1="608" x2="650.3333333333334" y1="1505" y2="1505" class="net_2"/>
+  <line x1="744.3333333333334" x2="761" y1="1440" y2="1440" class="net_29,30,31,32,33,34,35,36"/>
+  <line x1="761" x2="761" y1="1440" y2="1825" class="net_29,30,31,32,33,34,35,36"/>
+  <line x1="761" x2="786" y1="1825" y2="1825" class="net_29,30,31,32,33,34,35,36"/>
+  <line x1="809.3333333333334" x2="826" y1="1262.5" y2="1262.5" class="net_37,38,39,40,41,42,43,44,45,46,47,48,49,50,51"/>
+  <line x1="826" x2="826" y1="1262.5" y2="1357" class="net_37,38,39,40,41,42,43,44,45,46,47,48,49,50,51"/>
+  <line x1="826" x2="851" y1="1357" y2="1357" class="net_37,38,39,40,41,42,43,44,45,46,47,48,49,50,51"/>
+  <line x1="422" x2="598" y1="1780" y2="1780" class="net_98"/>
+  <line x1="598" x2="598" y1="1780" y2="1485" class="net_98"/>
+  <line x1="598" x2="650.3333333333334" y1="1485" y2="1485" class="net_98"/>
+  <line x1="668" x2="724.3333333333334" y1="1430" y2="1430" class="net_99,100,101,102,103,104,105,106"/>
+  <line x1="665" x2="706" y1="1572.5" y2="1572.5" class="net_68,21,22,23,24,25,26,27"/>
+  <line x1="706" x2="706" y1="1572.5" y2="1450" class="net_68,21,22,23,24,25,26,27"/>
+  <line x1="706" x2="724.3333333333334" y1="1450" y2="1450" class="net_68,21,22,23,24,25,26,27"/>
+  <line x1="680.3333333333334" x2="734.3333333333334" y1="1485" y2="1485" class="net_67"/>
+  <line x1="734.3333333333334" x2="734.3333333333334" y1="1485" y2="1455" class="net_67"/>
+  <line x1="680.3333333333334" x2="696" y1="1485" y2="1485" class="net_67"/>
+  <line x1="696" x2="696" y1="1485" y2="1388" class="net_67"/>
+  <line x1="696" x2="799.3333333333334" y1="1388" y2="1388" class="net_67"/>
+  <circle cx="696" cy="1485" r="2" style="fill:#000" class="net_67"/>
+  <line x1="799.3333333333334" x2="799.3333333333334" y1="1388" y2="1277.5" class="net_67"/>
+  <line x1="663.5" x2="696" y1="563" y2="563" class="net_69,70,71,72,73,74,75,68,76,77,78,79,80,81,82"/>
+  <line x1="696" x2="696" y1="563" y2="1262.5" class="net_69,70,71,72,73,74,75,68,76,77,78,79,80,81,82"/>
+  <line x1="696" x2="724.3333333333334" y1="1262.5" y2="1262.5" class="net_69,70,71,72,73,74,75,68,76,77,78,79,80,81,82"/>
+  <line x1="665" x2="724.3333333333334" y1="1282.5" y2="1282.5" class="net_13,14,15,16,17,18,19,20,107,108,109,110,111,112,113"/>
+  <line x1="666" x2="734.3333333333334" y1="1357" y2="1357" class="net_11"/>
+  <line x1="734.3333333333334" x2="734.3333333333334" y1="1357" y2="1287.5" class="net_11"/>
+  <line x1="751" x2="761" y1="1207.5" y2="1207.5" class="net_114,115,116,117,118,119,120,121,122,123,124,125,126,127,128"/>
+  <line x1="761" x2="761" y1="1207.5" y2="1252.5" class="net_114,115,116,117,118,119,120,121,122,123,124,125,126,127,128"/>
+  <line x1="761" x2="789.3333333333334" y1="1252.5" y2="1252.5" class="net_114,115,116,117,118,119,120,121,122,123,124,125,126,127,128"/>
+  <line x1="744.3333333333334" x2="789.3333333333334" y1="1272.5" y2="1272.5" class="net_83,84,85,86,87,88,89,90,91,92,93,94,95,96,97"/>
+  <line x1="327" x2="398" y1="143.5" y2="143.5" class="net_53,52,66"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="163.5" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="733" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="163.5" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="163.5" y2="163.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="918" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="918" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="392" y1="918" y2="918" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="1006" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="1006" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="392" y1="1006" y2="1006" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="1094" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="1094" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="392" y1="1094" y2="1094" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="1270" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="1270" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="392" y1="1270" y2="1270" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="1182" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="1182" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="392" y1="1182" y2="1182" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="75.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="75.5" y2="75.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="251.5" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="251.5" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="251.5" y2="251.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="339.5" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="339.5" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="339.5" y2="339.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="427.5" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="427.5" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="427.5" y2="427.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="515.5" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="515.5" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="515.5" y2="515.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="603.5" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="603.5" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="603.5" y2="603.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="1582.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="1582.5" y2="1582.5" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="398" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="332" x2="342" y1="733" y2="733" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="342" y1="733" y2="821" class="net_129,130,131,132,133,134,135,136"/>
+  <circle cx="342" cy="821" r="2" style="fill:#000" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="342" x2="398" y1="821" y2="821" class="net_129,130,131,132,133,134,135,136"/>
+  <line x1="327" x2="392" y1="898" y2="898" class="net_63,62,61"/>
+  <line x1="327" x2="392" y1="986" y2="986" class="net_64,63,62"/>
+  <line x1="327" x2="392" y1="1074" y2="1074" class="net_65,64,63"/>
+  <line x1="327" x2="392" y1="1250" y2="1250" class="net_66,65,64"/>
+  <line x1="323" x2="392" y1="1162" y2="1162" class="net_52,66,65"/>
+  <line x1="327" x2="398" y1="55.5" y2="55.5" class="net_54,53,52"/>
+  <line x1="327" x2="398" y1="231.5" y2="231.5" class="net_55,54,53"/>
+  <line x1="327" x2="398" y1="319.5" y2="319.5" class="net_56,55,54"/>
+  <line x1="327" x2="398" y1="407.5" y2="407.5" class="net_57,56,55"/>
+  <line x1="327" x2="398" y1="495.5" y2="495.5" class="net_58,57,56"/>
+  <line x1="327" x2="398" y1="583.5" y2="583.5" class="net_59,58,57"/>
+  <line x1="327" x2="398" y1="1562.5" y2="1562.5" class="net_60,59,58"/>
+  <line x1="327" x2="352" y1="658.5" y2="658.5" class="net_61,60,59"/>
+  <line x1="352" x2="352" y1="658.5" y2="713" class="net_61,60,59"/>
+  <line x1="352" x2="398" y1="713" y2="713" class="net_61,60,59"/>
+  <line x1="323" x2="398" y1="801" y2="801" class="net_62,61,60"/>
+  <line x1="816" x2="851" y1="1825" y2="1825" class="net_21,22,23,24,25,26,27,28"/>
+  <line x1="816" x2="826" y1="1825" y2="1825" class="net_21,22,23,24,25,26,27,28"/>
+  <line x1="826" x2="826" y1="1825" y2="1399" class="net_21,22,23,24,25,26,27,28"/>
+  <line x1="826" x2="618" y1="1399" y2="1399" class="net_21,22,23,24,25,26,27,28"/>
+  <line x1="618" x2="618" y1="1399" y2="1923" class="net_21,22,23,24,25,26,27,28"/>
+  <line x1="618" x2="417.5" y1="1923" y2="1923" class="net_21,22,23,24,25,26,27,28"/>
+  <circle cx="826" cy="1825" r="2" style="fill:#000" class="net_21,22,23,24,25,26,27,28"/>
+  <line x1="417.5" x2="417.5" y1="1923" y2="1911" class="net_21,22,23,24,25,26,27,28"/>
+  <line x1="429" x2="659" y1="1562.5" y2="1562.5" class="net_68"/>
+  <line x1="429" x2="568" y1="1562.5" y2="1562.5" class="net_68"/>
+  <line x1="568" x2="568" y1="1562.5" y2="693" class="net_68"/>
+  <circle cx="568" cy="1562.5" r="2" style="fill:#000" class="net_68"/>
+  <line x1="568" x2="657.5" y1="693" y2="693" class="net_68"/>
+  <line x1="422" x2="628" y1="1900.5" y2="1900.5" class="net_21,22,23,24,25,26,27"/>
+  <line x1="628" x2="628" y1="1900.5" y2="1582.5" class="net_21,22,23,24,25,26,27"/>
+  <line x1="628" x2="659" y1="1582.5" y2="1582.5" class="net_21,22,23,24,25,26,27"/>
+  <line x1="429" x2="658" y1="143.5" y2="143.5" class="net_69"/>
+  <line x1="658" x2="658" y1="143.5" y2="552.5" class="net_69"/>
+  <line x1="429" x2="658" y1="55.5" y2="55.5" class="net_70"/>
+  <line x1="658" x2="658" y1="55.5" y2="572.5" class="net_70"/>
+  <line x1="429" x2="598" y1="231.5" y2="231.5" class="net_71"/>
+  <line x1="598" x2="598" y1="231.5" y2="593" class="net_71"/>
+  <line x1="598" x2="657.5" y1="593" y2="593" class="net_71"/>
+  <line x1="429" x2="588" y1="319.5" y2="319.5" class="net_72"/>
+  <line x1="588" x2="588" y1="319.5" y2="613" class="net_72"/>
+  <line x1="588" x2="657.5" y1="613" y2="613" class="net_72"/>
+  <line x1="429" x2="578" y1="407.5" y2="407.5" class="net_73"/>
+  <line x1="578" x2="578" y1="407.5" y2="633" class="net_73"/>
+  <line x1="578" x2="657.5" y1="633" y2="633" class="net_73"/>
+  <line x1="429" x2="568" y1="495.5" y2="495.5" class="net_74"/>
+  <line x1="568" x2="568" y1="495.5" y2="653" class="net_74"/>
+  <line x1="568" x2="657.5" y1="653" y2="653" class="net_74"/>
+  <line x1="429" x2="558" y1="583.5" y2="583.5" class="net_75"/>
+  <line x1="558" x2="558" y1="583.5" y2="673" class="net_75"/>
+  <line x1="558" x2="657.5" y1="673" y2="673" class="net_75"/>
+  <line x1="429" x2="657.5" y1="713" y2="713" class="net_76"/>
+  <line x1="429" x2="558" y1="801" y2="801" class="net_77"/>
+  <line x1="558" x2="558" y1="801" y2="733" class="net_77"/>
+  <line x1="558" x2="657.5" y1="733" y2="733" class="net_77"/>
+  <line x1="423" x2="578" y1="898" y2="898" class="net_78"/>
+  <line x1="578" x2="578" y1="898" y2="753" class="net_78"/>
+  <line x1="578" x2="657.5" y1="753" y2="753" class="net_78"/>
+  <line x1="423" x2="588" y1="986" y2="986" class="net_79"/>
+  <line x1="588" x2="588" y1="986" y2="773" class="net_79"/>
+  <line x1="588" x2="657.5" y1="773" y2="773" class="net_79"/>
+  <line x1="423" x2="598" y1="1074" y2="1074" class="net_80"/>
+  <line x1="598" x2="598" y1="1074" y2="793" class="net_80"/>
+  <line x1="598" x2="657.5" y1="793" y2="793" class="net_80"/>
+  <line x1="423" x2="658" y1="1250" y2="1250" class="net_81"/>
+  <line x1="658" x2="658" y1="1250" y2="813.5" class="net_81"/>
+  <line x1="423" x2="658" y1="1162" y2="1162" class="net_82"/>
+  <line x1="658" x2="658" y1="1162" y2="833.5" class="net_82"/>
+  <line x1="420" x2="578" y1="1650" y2="1650" class="net_13,14,15,16,17,18,19,20"/>
+  <line x1="578" x2="578" y1="1650" y2="1272.5" class="net_13,14,15,16,17,18,19,20"/>
+  <line x1="578" x2="659" y1="1272.5" y2="1272.5" class="net_13,14,15,16,17,18,19,20"/>
+  <line x1="422" x2="588" y1="1715" y2="1715" class="net_107,108,109,110,111,112,113"/>
+  <line x1="588" x2="588" y1="1715" y2="1292.5" class="net_107,108,109,110,111,112,113"/>
+  <line x1="588" x2="659" y1="1292.5" y2="1292.5" class="net_107,108,109,110,111,112,113"/>
+  <line x1="267" x2="321" y1="133.5" y2="133.5" class="net_53,52"/>
+  <line x1="103.5" x2="103.5" y1="1149.5" y2="123.5" class="net_53"/>
+  <line x1="103.5" x2="261" y1="123.5" y2="123.5" class="net_53"/>
+  <line x1="103.5" x2="103.5" y1="1149.5" y2="123.5" class="net_53"/>
+  <line x1="103.5" x2="134" y1="123.5" y2="123.5" class="net_53"/>
+  <line x1="134" x2="134" y1="123.5" y2="55.5" class="net_53"/>
+  <circle cx="134" cy="123.5" r="2" style="fill:#000" class="net_53"/>
+  <line x1="134" x2="261" y1="55.5" y2="55.5" class="net_53"/>
+  <line x1="104" x2="114" y1="1170" y2="1170" class="net_52"/>
+  <line x1="114" x2="114" y1="1170" y2="143.5" class="net_52"/>
+  <line x1="114" x2="261" y1="143.5" y2="143.5" class="net_52"/>
+  <line x1="104" x2="114" y1="1170" y2="1170" class="net_52"/>
+  <line x1="114" x2="114" y1="1170" y2="1152" class="net_52"/>
+  <circle cx="114" cy="1152" r="2" style="fill:#000" class="net_52"/>
+  <line x1="114" x2="317" y1="1152" y2="1152" class="net_52"/>
+  <line x1="267" x2="321" y1="888" y2="888" class="net_63,62"/>
+  <line x1="104" x2="214" y1="1190" y2="1190" class="net_63"/>
+  <line x1="214" x2="214" y1="1190" y2="878" class="net_63"/>
+  <line x1="214" x2="261" y1="878" y2="878" class="net_63"/>
+  <line x1="104" x2="214" y1="1190" y2="1190" class="net_63"/>
+  <line x1="214" x2="214" y1="1190" y2="986" class="net_63"/>
+  <circle cx="214" cy="986" r="2" style="fill:#000" class="net_63"/>
+  <line x1="214" x2="261" y1="986" y2="986" class="net_63"/>
+  <line x1="104" x2="184" y1="1210" y2="1210" class="net_62"/>
+  <line x1="184" x2="184" y1="1210" y2="898" class="net_62"/>
+  <circle cx="184" cy="898" r="2" style="fill:#000" class="net_62"/>
+  <line x1="184" x2="261" y1="898" y2="898" class="net_62"/>
+  <line x1="104" x2="184" y1="1210" y2="1210" class="net_62"/>
+  <line x1="184" x2="184" y1="1210" y2="777.5" class="net_62"/>
+  <line x1="184" x2="287" y1="777.5" y2="777.5" class="net_62"/>
+  <line x1="287" x2="287" y1="777.5" y2="791" class="net_62"/>
+  <line x1="287" x2="317" y1="791" y2="791" class="net_62"/>
+  <line x1="267" x2="321" y1="976" y2="976" class="net_64,63"/>
+  <line x1="104" x2="224" y1="1230" y2="1230" class="net_64"/>
+  <line x1="224" x2="224" y1="1230" y2="966" class="net_64"/>
+  <line x1="224" x2="261" y1="966" y2="966" class="net_64"/>
+  <line x1="104" x2="224" y1="1230" y2="1230" class="net_64"/>
+  <line x1="224" x2="224" y1="1230" y2="1074" class="net_64"/>
+  <circle cx="224" cy="1074" r="2" style="fill:#000" class="net_64"/>
+  <line x1="224" x2="261" y1="1074" y2="1074" class="net_64"/>
+  <line x1="267" x2="321" y1="1064" y2="1064" class="net_65,64"/>
+  <line x1="104" x2="234" y1="1250" y2="1250" class="net_65"/>
+  <line x1="234" x2="234" y1="1250" y2="1054" class="net_65"/>
+  <circle cx="234" cy="1250" r="2" style="fill:#000" class="net_65"/>
+  <line x1="234" x2="261" y1="1054" y2="1054" class="net_65"/>
+  <line x1="104" x2="261" y1="1250" y2="1250" class="net_65"/>
+  <line x1="267" x2="321" y1="1240" y2="1240" class="net_66,65"/>
+  <line x1="267" x2="277" y1="1240" y2="1240" class="net_66,65"/>
+  <line x1="277" x2="277" y1="1240" y2="1172" class="net_66,65"/>
+  <circle cx="277" cy="1240" r="2" style="fill:#000" class="net_66,65"/>
+  <line x1="277" x2="317" y1="1172" y2="1172" class="net_66,65"/>
+  <line x1="104" x2="244" y1="1270" y2="1270" class="net_66"/>
+  <line x1="244" x2="244" y1="1270" y2="1230" class="net_66"/>
+  <line x1="244" x2="261" y1="1230" y2="1230" class="net_66"/>
+  <line x1="267" x2="321" y1="45.5" y2="45.5" class="net_54,53"/>
+  <line x1="104" x2="124" y1="1290" y2="1290" class="net_54"/>
+  <line x1="124" x2="124" y1="1290" y2="35.5" class="net_54"/>
+  <line x1="124" x2="261" y1="35.5" y2="35.5" class="net_54"/>
+  <line x1="104" x2="124" y1="1290" y2="1290" class="net_54"/>
+  <line x1="124" x2="124" y1="1290" y2="231.5" class="net_54"/>
+  <circle cx="124" cy="231.5" r="2" style="fill:#000" class="net_54"/>
+  <line x1="124" x2="261" y1="231.5" y2="231.5" class="net_54"/>
+  <line x1="267" x2="321" y1="221.5" y2="221.5" class="net_55,54"/>
+  <line x1="104" x2="134" y1="1310" y2="1310" class="net_55"/>
+  <line x1="134" x2="134" y1="1310" y2="211.5" class="net_55"/>
+  <line x1="134" x2="261" y1="211.5" y2="211.5" class="net_55"/>
+  <line x1="104" x2="134" y1="1310" y2="1310" class="net_55"/>
+  <line x1="134" x2="134" y1="1310" y2="319.5" class="net_55"/>
+  <circle cx="134" cy="319.5" r="2" style="fill:#000" class="net_55"/>
+  <line x1="134" x2="261" y1="319.5" y2="319.5" class="net_55"/>
+  <line x1="267" x2="321" y1="309.5" y2="309.5" class="net_56,55"/>
+  <line x1="104" x2="144" y1="1330" y2="1330" class="net_56"/>
+  <line x1="144" x2="144" y1="1330" y2="299.5" class="net_56"/>
+  <line x1="144" x2="261" y1="299.5" y2="299.5" class="net_56"/>
+  <line x1="104" x2="144" y1="1330" y2="1330" class="net_56"/>
+  <line x1="144" x2="144" y1="1330" y2="407.5" class="net_56"/>
+  <circle cx="144" cy="407.5" r="2" style="fill:#000" class="net_56"/>
+  <line x1="144" x2="261" y1="407.5" y2="407.5" class="net_56"/>
+  <line x1="267" x2="321" y1="397.5" y2="397.5" class="net_57,56"/>
+  <line x1="104" x2="154" y1="1350" y2="1350" class="net_57"/>
+  <line x1="154" x2="154" y1="1350" y2="387.5" class="net_57"/>
+  <line x1="154" x2="261" y1="387.5" y2="387.5" class="net_57"/>
+  <line x1="104" x2="154" y1="1350" y2="1350" class="net_57"/>
+  <line x1="154" x2="154" y1="1350" y2="495.5" class="net_57"/>
+  <circle cx="154" cy="495.5" r="2" style="fill:#000" class="net_57"/>
+  <line x1="154" x2="261" y1="495.5" y2="495.5" class="net_57"/>
+  <line x1="267" x2="321" y1="485.5" y2="485.5" class="net_58,57"/>
+  <line x1="104" x2="164" y1="1370" y2="1370" class="net_58"/>
+  <line x1="164" x2="164" y1="1370" y2="475.5" class="net_58"/>
+  <line x1="164" x2="261" y1="475.5" y2="475.5" class="net_58"/>
+  <line x1="104" x2="164" y1="1370" y2="1370" class="net_58"/>
+  <line x1="164" x2="164" y1="1370" y2="583.5" class="net_58"/>
+  <circle cx="164" cy="583.5" r="2" style="fill:#000" class="net_58"/>
+  <line x1="164" x2="261" y1="583.5" y2="583.5" class="net_58"/>
+  <line x1="267" x2="321" y1="573.5" y2="573.5" class="net_59,58"/>
+  <line x1="104" x2="174" y1="1390" y2="1390" class="net_59"/>
+  <line x1="174" x2="174" y1="1390" y2="563.5" class="net_59"/>
+  <circle cx="174" cy="1390" r="2" style="fill:#000" class="net_59"/>
+  <line x1="174" x2="261" y1="563.5" y2="563.5" class="net_59"/>
+  <line x1="104" x2="174" y1="1390" y2="1390" class="net_59"/>
+  <line x1="174" x2="174" y1="1390" y2="1562.5" class="net_59"/>
+  <line x1="174" x2="261" y1="1562.5" y2="1562.5" class="net_59"/>
+  <line x1="267" x2="321" y1="1552.5" y2="1552.5" class="net_60,59"/>
+  <line x1="103.5" x2="103.5" y1="1410.5" y2="1542.5" class="net_60"/>
+  <line x1="103.5" x2="261" y1="1542.5" y2="1542.5" class="net_60"/>
+  <line x1="103.5" x2="103.5" y1="1410.5" y2="1542.5" class="net_60"/>
+  <line x1="103.5" x2="204" y1="1542.5" y2="1542.5" class="net_60"/>
+  <line x1="204" x2="204" y1="1542.5" y2="821" class="net_60"/>
+  <circle cx="204" cy="1542.5" r="2" style="fill:#000" class="net_60"/>
+  <line x1="204" x2="261" y1="821" y2="821" class="net_60"/>
+  <line x1="267" x2="277" y1="811" y2="811" class="net_61,60"/>
+  <line x1="277" x2="277" y1="811" y2="648.5" class="net_61,60"/>
+  <circle cx="277" cy="811" r="2" style="fill:#000" class="net_61,60"/>
+  <line x1="277" x2="321" y1="648.5" y2="648.5" class="net_61,60"/>
+  <line x1="267" x2="317" y1="811" y2="811" class="net_61,60"/>
+  <line x1="103.5" x2="103.5" y1="1430.5" y2="1449.5" class="net_61"/>
+  <line x1="103.5" x2="194" y1="1449.5" y2="1449.5" class="net_61"/>
+  <line x1="194" x2="194" y1="1449.5" y2="801" class="net_61"/>
+  <line x1="194" x2="261" y1="801" y2="801" class="net_61"/>
+  <line x1="881" x2="891" y1="1357" y2="1357" class="net_52,53,54,55,56,57,58,59,60,61,62,63,64,65,66"/>
+  <line x1="891" x2="891" y1="1357" y2="12" class="net_52,53,54,55,56,57,58,59,60,61,62,63,64,65,66"/>
+  <line x1="891" x2="99.5" y1="12" y2="12" class="net_52,53,54,55,56,57,58,59,60,61,62,63,64,65,66"/>
+  <line x1="99.5" x2="99.5" y1="12" y2="1159.5" class="net_52,53,54,55,56,57,58,59,60,61,62,63,64,65,66"/>
 </svg>


### PR DESCRIPTION
With Wolfram rule 30, randomness is observed in the "central column" of the Automaton, so at each generation we keep the central bit:  we add it as LSB to the RAND module output (and we discard the MSB) using a shif register.