### PR TITLE
Fix Not marking ControlUnit.state as FSM state register

### DIFF
--- a/verilog/ControlUnit.v
+++ b/verilog/ControlUnit.v
@@ -81,13 +81,9 @@ module ControlUnit (
     o_SET      = 4'b 1110,
     o_HALT     = 4'b 1111;
 
-    reg [4:0] state = 0;
+    reg [4:0] state;
     reg [4:0] nextstate;
 
-    initial begin
-      state = S_RESET; // 5'b 00000; // only value we can initialize correctly
-    end
-    
     // comb always block
     // NEXT STATE LOGIC (depends on currState and INPUTS)
     always @* begin


### PR DESCRIPTION
ControlUnit.state as FSM state register: Register has an initialization value

Remove initialization value